### PR TITLE
[PHP] Add request replayer image

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,13 @@
+### Requests replayer
+
+Build:
+
+```
+docker-compose build request-replayer
+```
+
+Publish:
+
+```
+docker-compose push request-replayer
+```

--- a/php/docker-compose.yml
+++ b/php/docker-compose.yml
@@ -5,4 +5,3 @@ services:
     image: docker.pkg.github.com/datadog/dd-trace-ci/php-request-replayer
     build:
       context: request-replayer
-    command: sh /app_start.sh

--- a/php/docker-compose.yml
+++ b/php/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.7'
+
+services:
+  request-replayer:
+    image: docker.pkg.github.com/datadog/dd-trace-ci/php-request-replayer
+    build:
+      context: request-replayer
+    ports:
+      - 9090:80
+    command: sh /app_start.sh

--- a/php/docker-compose.yml
+++ b/php/docker-compose.yml
@@ -5,6 +5,4 @@ services:
     image: docker.pkg.github.com/datadog/dd-trace-ci/php-request-replayer
     build:
       context: request-replayer
-    ports:
-      - 9090:80
     command: sh /app_start.sh

--- a/php/request-replayer/Dockerfile
+++ b/php/request-replayer/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:7.3
+
+RUN apt-get update \
+  && apt-get install -y git \
+  && apt-get install -y unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www
+
+RUN (curl -q https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer | php -- --filename=composer --install-dir=/usr/local/bin);
+
+COPY src /var/www
+COPY app_start.sh /app_start.sh
+
+CMD composer install --prefer-dist && php -S 0.0.0.0:80 index.php

--- a/php/request-replayer/Dockerfile
+++ b/php/request-replayer/Dockerfile
@@ -12,4 +12,8 @@ RUN (curl -q https://raw.githubusercontent.com/composer/getcomposer.org/76a7060c
 COPY src /var/www
 COPY app_start.sh /app_start.sh
 
-CMD composer install --prefer-dist && php -S 0.0.0.0:80 index.php
+EXPOSE 80
+
+RUN composer install
+
+CMD [ "php", "-S", "0.0.0.0:80", "index.php" ]

--- a/php/request-replayer/Dockerfile
+++ b/php/request-replayer/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /var/www
 RUN (curl -q https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer | php -- --filename=composer --install-dir=/usr/local/bin);
 
 COPY src /var/www
-COPY app_start.sh /app_start.sh
 
 EXPOSE 80
 

--- a/php/request-replayer/Dockerfile
+++ b/php/request-replayer/Dockerfile
@@ -1,8 +1,7 @@
 FROM php:7.3
 
 RUN apt-get update \
-  && apt-get install -y git \
-  && apt-get install -y unzip \
+  && apt-get install -y git unzip \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /var/www

--- a/php/request-replayer/app_start.sh
+++ b/php/request-replayer/app_start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+composer install
+
+php -S 0.0.0.0:80 index.php

--- a/php/request-replayer/app_start.sh
+++ b/php/request-replayer/app_start.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-composer install
-
-php -S 0.0.0.0:80 index.php

--- a/php/request-replayer/src/composer.json
+++ b/php/request-replayer/src/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "root/request_replayer",
+    "require": {
+        "rybakit/msgpack": "^0.5.4"
+    }
+}

--- a/php/request-replayer/src/index.php
+++ b/php/request-replayer/src/index.php
@@ -1,0 +1,60 @@
+<?php
+
+include __DIR__ . '/vendor/autoload.php';
+
+use MessagePack\MessagePack;
+
+if ('cli-server' !== PHP_SAPI) {
+    echo "For use via the CLI SAPI's built-in web server only.\n";
+    exit;
+}
+
+define('REQUEST_LOG_FILE', sys_get_temp_dir() . '/dump.json');
+
+function logRequest($message, $data = '')
+{
+    if (!empty($data)) {
+        $message .= ":\n" . $data;
+    }
+    error_log(
+        sprintf('[%s | %s] %s', $_SERVER['REQUEST_URI'], REQUEST_LOG_FILE, $message)
+    );
+}
+
+switch ($_SERVER['REQUEST_URI']) {
+    case '/replay':
+        if (!file_exists(REQUEST_LOG_FILE)) {
+            logRequest('Cannot replay last request; request log does not exist');
+            break;
+        }
+        $request = file_get_contents(REQUEST_LOG_FILE);
+        echo $request;
+        unlink(REQUEST_LOG_FILE);
+        logRequest('Returned last request and deleted request log', $request);
+        break;
+    case '/clear-dumped-data':
+        if (!file_exists(REQUEST_LOG_FILE)) {
+            logRequest('Cannot delete request log; request log does not exist');
+            break;
+        }
+        unlink(REQUEST_LOG_FILE);
+        logRequest('Deleted request log');
+        break;
+    default:
+        $headers = getallheaders();
+
+        $raw = file_get_contents('php://input');
+        if (isset($headers['Content-Type']) && $headers['Content-Type'] === 'application/msgpack') {
+            $body = json_encode(MessagePack::unpack($raw));
+        } else {
+            $body = $raw;
+        }
+        $value = json_encode([
+            'uri' => $_SERVER['REQUEST_URI'],
+            'headers' => $headers,
+            'body' => $body,
+        ]);
+        file_put_contents(REQUEST_LOG_FILE, $value);
+        logRequest('Logged new request', $value);
+        break;
+}

--- a/php/request-replayer/src/test_send_msgpack.php
+++ b/php/request-replayer/src/test_send_msgpack.php
@@ -1,0 +1,28 @@
+<?php
+
+include __DIR__ . '/vendor/autoload.php';
+
+use MessagePack\MessagePack;
+
+$msgpack = MessagePack::pack([
+    "sample" => "value",
+]);
+
+$ch = curl_init();
+
+curl_setopt($ch, CURLOPT_URL,"localhost");
+curl_setopt($ch, CURLOPT_PORT, 80);
+curl_setopt($ch, CURLOPT_POST, 1);
+curl_setopt($ch, CURLOPT_POSTFIELDS, $msgpack);
+
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Content-Type: application/msgpack',
+]);
+
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+$server_output = curl_exec($ch);
+
+curl_close ($ch);
+
+print_r($server_output);


### PR DESCRIPTION
This image is the one used by the php tracer both locally an in CI to verify the proper spans are sent to the agent.

Only one image is present, instead of one image per PHP version, because here the PHP version is not relevant as the PHP version that is actually relevant is in the test executor (different image).