### PR TITLE
Mysql image for integrations tests

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -11,3 +11,17 @@ Publish:
 ```
 docker-compose push request-replayer
 ```
+
+### Mysql
+
+Build:
+
+```
+docker-compose build mysql-dev
+```
+
+Publish:
+
+```
+docker-compose push mysql-dev
+```

--- a/php/docker-compose.yml
+++ b/php/docker-compose.yml
@@ -5,3 +5,8 @@ services:
     image: docker.pkg.github.com/datadog/dd-trace-ci/php-request-replayer
     build:
       context: request-replayer
+
+  mysql-dev:
+    image: docker.pkg.github.com/datadog/dd-trace-ci/php-mysql-dev:5.6
+    build:
+      context: mysql

--- a/php/mysql/Dockerfile
+++ b/php/mysql/Dockerfile
@@ -1,0 +1,3 @@
+FROM mysql:5.6
+
+COPY init.sql /docker-entrypoint-initdb.d/init.sql

--- a/php/mysql/init.sql
+++ b/php/mysql/init.sql
@@ -1,0 +1,9 @@
+create table users (
+    id integer not null primary key auto_increment,
+    email varchar(100) not null unique,
+    name varchar(100),
+    password varchar(100),
+    remember_token varchar(100),
+    updated_at timestamp,
+    created_at timestamp
+);


### PR DESCRIPTION
This image is based on mysql:5.6 and is a replacement for the native `mysql:5.6` image that we used previously.

In addition to it this image adds basic fixtures that can be used in tests.