### PR TITLE
[PHP] Move Supervisor "nodaemon" config to CMD

### DIFF
--- a/php/nginx-apache2/Dockerfile
+++ b/php/nginx-apache2/Dockerfile
@@ -33,4 +33,4 @@ RUN mkdir -p /src/ddtrace && cd $_ \
     && dpkg-deb -R datadog-php-tracer_0.35.0_amd64.deb . \
     && cp -a ./opt/. /opt/
 
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "--nodaemon"]

--- a/php/nginx-apache2/supervisord.conf
+++ b/php/nginx-apache2/supervisord.conf
@@ -1,6 +1,3 @@
-[supervisord]
-nodaemon=true
-
 [program:apache2]
 command=/usr/bin/pidproxy /var/run/apache2/apache2.pid /bin/bash -c "/usr/sbin/apache2ctl -DFOREGROUND"
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
When running from CircleCI tests, supervisord needs to run in the background.