### PR TITLE
[PHP] Update buster and Centos containers

### DIFF
--- a/php/buster/Dockerfile
+++ b/php/buster/Dockerfile
@@ -166,19 +166,19 @@ ENV PHP_VERSION 7.0.33
 ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.gz/from/this/mirror"
 
 FROM basic_system as php_source_v7_1
-ENV PHP_VERSION 7.1.30
+ENV PHP_VERSION 7.1.33
 ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.gz/from/this/mirror"
 
 FROM basic_system as php_source_v7_2
-ENV PHP_VERSION 7.2.20
+ENV PHP_VERSION 7.2.27
 ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.gz/from/this/mirror"
 
 FROM basic_system as php_source_v7_3
-ENV PHP_VERSION 7.3.6
+ENV PHP_VERSION 7.3.14
 ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.gz/from/this/mirror"
 
 FROM basic_system as php_source_v7_4
-ENV PHP_VERSION 7.4.1
+ENV PHP_VERSION 7.4.2
 ENV PHP_URL="https://www.php.net/get/php-${PHP_VERSION}.tar.gz/from/this/mirror"
 
 FROM php_source_${VERSION} as php_source
@@ -224,7 +224,7 @@ COPY docker-php-ext-*  /usr/local/bin/
 ARG PHP_CONFIG_ARGS=""
 ARG BASE_CONFIG_ARGS="--with-apxs2"
 ENV PHP_CFLAGS="-fpic -fpie"
-ENV PHP_LDFLAGS="-Wl,-O1 -Wl,--hash-style=both -pie"
+ENV PHP_LDFLAGS="-Wl,-O0 -Wl,--hash-style=both -pie"
 ENV PHP_LIBS=""
 
 # Version specific configure args
@@ -272,7 +272,7 @@ ENV PHP_EXTRA_CONFIGURE_ARGS ${BASE_CONFIG_ARGS} --with-password-argon2 --with-s
 # Variant specific configure args
 
 FROM config-$VERSION as config-variant-vanilla
-ENV PHP_CFLAGS "-fstack-protector-strong -fpic -fpie -O2"
+ENV PHP_CFLAGS "-fstack-protector-strong -fpic -fpie -O0"
 
 FROM config-$VERSION as config-variant-debug
 ENV PHP_EXTRA_CONFIGURE_ARGS --enable-debug ${PHP_EXTRA_CONFIGURE_ARGS}
@@ -376,29 +376,12 @@ RUN set -eux; \
         ${PHP_EXTRA_CONFIGURE_ARGS:-} \
     ; \
     make -j "$(nproc)"; \
-    find -type f -name '*.a' -delete; \
     make install; \
-    find /usr/local/bin /usr/local/sbin -type f -executable -exec strip --strip-all '{}' + || true; \
-    make clean; \
     \
 # https://github.com/docker-library/php/issues/692 (copy default example "php.ini" files somewhere easily discoverable)
     cp -v php.ini-* "$PHP_INI_DIR/"; \
     \
     cd /; \
-    docker-php-source delete; \
-    \
-# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
-    apt-mark auto '.*' > /dev/null; \
-    [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
-    find /usr/local -type f -executable -exec ldd '{}' ';' \
-        | awk '/=>/ { print $(NF-1) }' \
-        | sort -u \
-        | xargs -r dpkg-query --search \
-        | cut -d: -f1 \
-        | sort -u \
-        | xargs -r apt-mark manual; \
-    \
-    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     \
 # update pecl channel definitions https://github.com/docker-library/php/issues/443
     pecl update-channels; \
@@ -419,7 +402,6 @@ RUN set -xe; \
     sudo apt-get -y install $EXT_DEPS; \
     phpize; ./configure --disable-memcached-sasl; \
     make install; \
-    sudo apt-get remove $EXT_DEP; \
     cd ..; rm -rf memcached; \
     yes 'no' | pecl install mongo; \
     docker-php-ext-enable memcached; \
@@ -436,7 +418,6 @@ RUN set -xe; \
     sudo apt-get -y install $EXT_DEPS; \
     yes 'no' | pecl install memcached; \
     docker-php-ext-enable memcached; \
-    sudo apt-get remove $EXT_DEP; \
     pecl install redis; \
     docker-php-ext-enable redis; \
     docker-php-ext-enable sodium 2> /dev/null || true

--- a/php/centos/Dockerfile
+++ b/php/centos/Dockerfile
@@ -12,7 +12,20 @@ RUN set -xe; \
   scl enable devtoolset-7 bash; \
   echo source scl_source enable devtoolset-7 | tee /etc/profile.d/enable-gcc7.sh
 ARG PHP_VERSION=54
-RUN yum-config-manager --enable remi-php${PHP_VERSION} \
-  && yum install -y php php-cli php-mcrypt php-devel php-xml \
-  && yum clean all \
-  && curl -q https://raw.githubusercontent.com/composer/getcomposer.org/1b137f8bf6db3e79a38a5bc45324414a6b1f9df2/web/installer | php -- php -- --filename=composer --install-dir=/usr/local/bin
+RUN set -eux; \
+  yum-config-manager --enable remi-php${PHP_VERSION}; \
+  yum install -y php php-cli php-mcrypt php-mbstring php-mysqlnd php-pdo php-devel php-xml; \
+  yum clean all; \
+  curl -q https://raw.githubusercontent.com/composer/getcomposer.org/1b137f8bf6db3e79a38a5bc45324414a6b1f9df2/web/installer | php -- php -- --filename=composer --install-dir=/usr/local/bin
+
+# Install PHP-FPM
+RUN set -eux; \
+    yum install -y php-fpm; \
+    mkdir -p /run/php-fpm; \
+    # Allow any IP address to listen to PHP-FPM & don't clear the env \
+    sed -e '/listen\.allowed_clients/d' -e 's/listen = .*/listen = 9000/g' -e 's/;clear_env = .*/clear_env = no/g' -i /etc/php-fpm.d/www.conf; \
+    # This line generates errors (no ext/soap) so delete it \
+    sed -e '/php_value\[soap\.wsdl_cache_dir\].*/d' -i /etc/php-fpm.d/www.conf; \
+    # Catch worker output and send error log to proper place \
+    sed -e 's/php_admin_value\[error_log\].*/php_admin_value[error_log] = \/proc\/self\/fd\/2/g' -e 's/;catch_workers_output = .*/catch_workers_output = yes/g' -i /etc/php-fpm.d/www.conf; \
+    sed -e 's/error_log = .*/error_log = \/proc\/self\/fd\/2/g' -i /etc/php-fpm.conf

--- a/php/docker-compose.yml
+++ b/php/docker-compose.yml
@@ -75,12 +75,61 @@ services:
         php_config_args: --enable-debug
         alpine_version: 3.11
 
+  5.4-debug-buster:
+    image: datadog/dd-trace-ci:php-5.4-debug-buster
+    build:
+      context: buster
+      target: final
+      args: { VERSION: v5_4, VARIANT: debug }
+
+  5.6-debug-buster:
+    image: datadog/dd-trace-ci:php-5.6-debug-buster
+    build:
+      context: buster
+      target: final
+      args: { VERSION: v5_6, VARIANT: debug }
+
+  7.0-debug-buster:
+    image: datadog/dd-trace-ci:php-7.0-debug-buster
+    build:
+      context: buster
+      target: final
+      args: { VERSION: v7_0, VARIANT: debug }
+
+  7.1-debug-buster:
+    image: datadog/dd-trace-ci:php-7.1-debug-buster
+    build:
+      context: buster
+      target: final
+      args: { VERSION: v7_1, VARIANT: debug }
+
+  7.2-debug-buster:
+    image: datadog/dd-trace-ci:php-7.2-debug-buster
+    build:
+      context: buster
+      target: final
+      args: { VERSION: v7_2, VARIANT: debug }
+
+  7.3-debug-buster:
+    image: datadog/dd-trace-ci:php-7.3-debug-buster
+    build:
+      context: buster
+      target: final
+      args: { VERSION: v7_3, VARIANT: debug }
+
   7.4-debug-buster:
     image: datadog/dd-trace-ci:php-7.4-debug-buster
     build:
       context: buster
       target: final
       args: { VERSION: v7_4, VARIANT: debug }
+
+  7.4-debug-asan-buster:
+    image: datadog/dd-trace-ci:php-7.4-debug-asan-buster
+    build:
+      context: buster
+      target: final
+      args: { VERSION: v7_4, VARIANT: debug-asan }
 
   framework-flow:
     image: datadog/dd-trace-ci:php-framework-flow


### PR DESCRIPTION
This PR updates the buster containers to the latest versions of PHP. It also makes PHP 5.6 through PHP 7.4 debug builds available for the dd-trace-php CI language tests. And all the source files and debug symbols are now kept for better debugging. The containers that were added are:

- `datadog/dd-trace-ci:php-7.4-debug-asan-buster`
- `datadog/dd-trace-ci:php-7.3-debug-buster`
- `datadog/dd-trace-ci:php-7.2-debug-buster`
- `datadog/dd-trace-ci:php-7.1-debug-buster`
- `datadog/dd-trace-ci:php-7.0-debug-buster`
- `datadog/dd-trace-ci:php-5.6-debug-buster`
- `datadog/dd-trace-ci:php-5.4-debug-buster`

This PR also contains an update to the Centos container `datadog/dd-trace-ci:php-7.4-centos-7` that includes PHP-FPM, `ext/mbstring` and PDO MySQL.