### PR TITLE
feat(python): install Cython in the Docker image

### DIFF
--- a/python/dev/Dockerfile
+++ b/python/dev/Dockerfile
@@ -61,6 +61,6 @@ RUN \
 # Install Python dependencies
 # DEV: `tox==3.7` introduced parallel execution mode
 #      https://tox.readthedocs.io/en/3.7.0/example/basic.html#parallel-mode
-RUN pip install "tox>=3.7,<4.0"
+RUN pip install "tox>=3.7,<4.0" cython
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Required by https://github.com/DataDog/dd-trace-py/pull/1203