### PR TITLE
PHP: Do not replay diagnostic checks in request-replayer

### DIFF
--- a/php/request-replayer/src/index.php
+++ b/php/request-replayer/src/index.php
@@ -42,6 +42,10 @@ switch ($_SERVER['REQUEST_URI']) {
         break;
     default:
         $headers = getallheaders();
+        if (isset($headers['X-Datadog-Diagnostic-Check'])) {
+            logRequest('Received diagnostic check; ignoring');
+            break;
+        }
 
         $raw = file_get_contents('php://input');
         if (isset($headers['Content-Type']) && $headers['Content-Type'] === 'application/msgpack') {


### PR DESCRIPTION
The `request-replayer` is the fake Agent used in CI checks for the PHP tracer. A recent update in DataDog/dd-trace-php#961 makes a diagnostic request to the Agent on the first request. This empty request gets logged by the `request-replayer` and breaks the following test request. This PR makes sure that diagnostic request checks are ignored.