### PR TITLE
Enable PHP embed SAPI

### DIFF
--- a/php/buster/Dockerfile
+++ b/php/buster/Dockerfile
@@ -361,6 +361,7 @@ RUN set -eux; \
         \
 # https://github.com/docker-library/php/issues/439
         --with-mhash \
+        --enable-embed \
         \
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
         --enable-ftp \


### PR DESCRIPTION
This enabled the PHP embed SAPI. In particular I'm hoping to use it to write unit tests for dd-trace-php without having to run PHP code, just C code.