### PR TITLE
Disable embed SAPI to be able to build images again with pcntl

### DIFF
--- a/php/buster/Dockerfile
+++ b/php/buster/Dockerfile
@@ -363,7 +363,9 @@ RUN set -eux; \
         \
 # https://github.com/docker-library/php/issues/439
         --with-mhash \
-        --enable-embed \
+# Disabling embed SAPI until we find a strategy to build both the "embed" + "apache2handler":
+# Error raised: "You've configured multiple SAPIs to be build. You can build only one SAPI module plus CGI, CLI and FPM binaries at the same time."
+        # --enable-embed \
         \
 # --enable-ftp is included here because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
         --enable-ftp \
@@ -380,6 +382,7 @@ RUN set -eux; \
         --enable-opcache \
         --enable-fpm \
         --enable-cgi \
+        --enable-pcntl \
         --with-fpm-user=www-data \
         --with-fpm-group=www-data \
         --with-pear \


### PR DESCRIPTION
7.x debug buster images from cannot be currently built on master as of [this PR](https://github.com/DataDog/dd-trace-ci/pull/27/files).

An error is generated at build time due to the added embed SAPI.

```
 +--------------------------------------------------------------------+
 |                        *** ATTENTION ***                           |
 |                                                                    |
 | You've configured multiple SAPIs to be build. You can build only   |
 | one SAPI module plus CGI, CLI and FPM binaries at the same time.   |
 +--------------------------------------------------------------------+
```

We currently build

```
$ php-config --php-sapis
apache2handler cli fpm phpdbg cgi
```

As a temporarily workaround I disabled the embed SAPI on 7, but we need to agree on a strategy to include all the SAPI.

Since some work is required, once we agree on what we want to do I can invest some time to move out of dd-trace-ci into the new approach already experimented for PHP 8 development machines, having all the versions in the same container.